### PR TITLE
Add kube-burner cluster-density-ms and update plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mv kube-burner kube-burner-0.14.2
 RUN cp -r /app/web-burner/workload /app/web-burner/objectTemplates /app/
 RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz 
 RUN tar -xzf openshift-client-linux.tar.gz -C /usr/local/bin
-RUN curl -L https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.2/kube-burner-1.4.2-Linux-x86_64.tar.gz | tar xz -C /app/ kube-burner
+RUN curl -L https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.5/kube-burner-1.5-Linux-x86_64.tar.gz | tar xz -C /app/ kube-burner
 RUN python3.9 -m pip install -r requirements.txt
 WORKDIR /app
 ENTRYPOINT ["python3", "arcaflow_plugin_kubeburner/kubeburner_plugin.py"]

--- a/arcaflow_plugin_kubeburner/kubeburner_plugin.py
+++ b/arcaflow_plugin_kubeburner/kubeburner_plugin.py
@@ -29,7 +29,7 @@ from helper_functions import (
     id="kube-burner",
     name="Kube-Burner Workload",
     description="""Kube-burner Workloads: node-density, node-density-cni,
-                node-density-heavy, cluster-density, cluster-density-v2""",
+                node-density-heavy, cluster-density, cluster-density-v2, cluster-density-ms """,
     outputs={"success": SuccessOutput, "error": ErrorOutput},
 )
 def RunKubeBurner(
@@ -97,7 +97,7 @@ def RunWebBurner(
     os.environ["QPS"] = str(params.qps)
     os.environ["BURST"] = str(params.burst)
     os.environ["INDEXING"] = params.indexing
-    os.environ["NORMAL_LIMIT_COUNT"] = str(
+    os.environ["LIMITCOUNT"] = str(
         calculate_normal_limit_count(params.number_of_nodes)
     )
     os.environ["ES_SERVER"] = str(params.es_server)
@@ -169,6 +169,9 @@ def DeleteWebBurner(
     os.environ["BURST"] = str(params.burst)
     os.environ["ES_SERVER"] = str(params.es_server)
     os.environ["ES_INDEX"] = str(params.es_index)
+    os.environ["LIMITCOUNT"] = str(
+        calculate_normal_limit_count(params.number_of_nodes)
+    )
     prom_url, prom_token = get_prometheus_creds()
 
     try:

--- a/arcaflow_plugin_kubeburner/kubeburner_schema.py
+++ b/arcaflow_plugin_kubeburner/kubeburner_schema.py
@@ -63,7 +63,7 @@ class KubeBurnerInput:
     log_level: typing.Annotated[
         typing.Optional[str],
         schema.name("log-level"),
-        schema.description("Allowed values: trace, debug, info, warn, error, fatal"),
+        schema.description("Allowed values: debug, info, warn, error, fatal"),
     ] = "info"
 
     timeout: typing.Annotated[
@@ -139,6 +139,12 @@ class KubeBurnerInput:
             "Percentage of job iterations that kube-burner will churn each round"
         ),
     ] = 10
+
+    local_indexing: typing.Annotated[
+        typing.Optional[str],
+        schema.name("local-indexing"),
+        schema.description("Enable local indexing"),
+    ] = "false"
 
 
 @dataclass

--- a/configs/kubeburner_cluster_density_input.yaml
+++ b/configs/kubeburner_cluster_density_input.yaml
@@ -1,7 +1,7 @@
 workload: 'cluster-density'
 uuid: 'a9ddd61b-d12e-4922-86a2-ea17354d80hh'
-es_server: 'https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443'
-es_index: 'ripsaw-kube-burner'
+es_server: ''
+es_index: ''
 qps: 20
 burst: 20
 log_level: 'info'

--- a/configs/kubeburner_node_density_input.yaml
+++ b/configs/kubeburner_node_density_input.yaml
@@ -1,7 +1,7 @@
 workload: 'node-density'
 uuid: 'a9ddd61b-d12e-4922-86a2-ea17354d80hh'
-es_server: 'https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443'
-es_index: 'ripsaw-kube-burner'
+es_server: ''
+es_index: ''
 qps: 20
 burst: 20
 log_level: 'info'

--- a/configs/webburner_cleanup_input.yaml
+++ b/configs/webburner_cleanup_input.yaml
@@ -1,5 +1,6 @@
 workload_template: 'cfg_delete_icni2_node_density2.yml'
 scale_factor: 2
+number_of_nodes: 3
 bfd_enabled: false
 uuid: 'poiy761b-d12e-4922-86a2-ea17354d80hh'
 kubeconfig: |

--- a/configs/webburner_input.yaml
+++ b/configs/webburner_input.yaml
@@ -1,10 +1,11 @@
 workload_template: 'cfg_icni2_node_density2.yml'
 scale_factor: 2
+number_of_nodes: 3
 bfd_enabled: false
 uuid: 'poiy761b-d12e-4922-86a2-ea17354d80hh'
 indexing: true
-es_server: 'https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443'
-es_index: 'ripsaw-kube-burner'
+es_server: ''
+es_index: ''
 kubeconfig: |
   apiVersion: v1
   clusters:

--- a/test_kubeburner_plugin.py
+++ b/test_kubeburner_plugin.py
@@ -11,7 +11,7 @@ class KubeburnerPluginTest(unittest.TestCase):
         plugin.test_object_serialization(
             kubeburner_plugin.KubeBurnerInputParams(
                 workload="node-density",
-                es_server="https://search-dev-chm.west-2.es.amazonaws.com:443",
+                es_server="https://search-dev-dummy.west-2.es.amazonaws.com:443",
                 es_index="index",
                 kubeconfig="abc",
             )


### PR DESCRIPTION
This PR adds the following:
1. adds the new cluster-density-ms (managed-services) workload to the plugin. 
2. adds new kube-burner flags 
3. updates the kube-burner version to 1.5 from 1.4.2
4. adds support to the web-buner fix to handle variable number of nodes in the baremetal cluster [web-burner PR](https://github.com/redhat-performance/web-burner/pull/52)